### PR TITLE
Fix User#save_albums!

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -394,8 +394,8 @@ module RSpotify
     def save_albums!(albums)
       albums_ids = albums.map(&:id)
       url = "me/albums"
-      request_body = albums_ids.inspect
-      User.oauth_put(@id, url, request_body)
+      request_body = { ids: albums_ids }
+      User.oauth_put(@id, url, request_body.to_json)
       albums
     end
 


### PR DESCRIPTION
Spotify changed api to so put /me/albums takes ONLY a request body w/ json {ids: [1,2,3]}. Previously it also took /me/albums/1,2,3